### PR TITLE
fix: ensure median ordering acts on sorted word list

### DIFF
--- a/src/benchmarks/benchmark_ternary_search_tree.py
+++ b/src/benchmarks/benchmark_ternary_search_tree.py
@@ -141,7 +141,7 @@ class BenchmarkTernaryTestTree:
             self.shuffled_populated_tree.insert(word)
 
         # median ordered words
-        self.median_ordered_words = self._median_order(words)
+        self.median_ordered_words = self._median_order(self.sorted_words)
         self.median_populated_tree = TernarySearchTree()
         for word in self.median_ordered_words:
             self.median_populated_tree.insert(word)


### PR DESCRIPTION
This PR contains a small fix that ensures the median ordering of words (needed to realize the best-case benchmark for `insert` and `search`) is done based on a sorted input list.